### PR TITLE
PlaceholderAPI Relational Placeholder Support

### DIFF
--- a/chat-formatter/src/com/eternalcode/formatter/ChatController.java
+++ b/chat-formatter/src/com/eternalcode/formatter/ChatController.java
@@ -73,7 +73,7 @@ class ChatController implements Listener {
 
         message = this.templateService.applyTemplates(message);
 
-        if (this.settings.isRelationalPlaceholders()) {
+        if (this.settings.isRelationalPlaceholdersEnabled()) {
             Map<Player, Component> messageComponents = new LinkedHashMap<>();
 
             for (Player recipient : new HashSet<>(event.getRecipients())) {

--- a/chat-formatter/src/com/eternalcode/formatter/ChatFormatterPlugin.java
+++ b/chat-formatter/src/com/eternalcode/formatter/ChatFormatterPlugin.java
@@ -48,6 +48,7 @@ public class ChatFormatterPlugin extends JavaPlugin implements ChatFormatter {
         this.placeholderRegistry = new PlaceholderRegistry();
         this.placeholderRegistry.stack(pluginConfig);
         this.placeholderRegistry.playerStack(new PlaceholderAPIStack());
+        this.placeholderRegistry.doublePlayerStack(new PlaceholderAPIStack());
         this.templateService = new TemplateService(pluginConfig);
         this.rankProvider = new VaultRankProvider(this.getServer());
         this.chatPreparatoryService = new ChatPreparatoryService();

--- a/chat-formatter/src/com/eternalcode/formatter/ChatSettings.java
+++ b/chat-formatter/src/com/eternalcode/formatter/ChatSettings.java
@@ -4,7 +4,7 @@ public interface ChatSettings {
 
     boolean isPreFormatting();
 
-    boolean isRelationalPlaceholders();
+    boolean isRelationalPlaceholdersEnabled();
 
     String getRawFormat(String rank);
 

--- a/chat-formatter/src/com/eternalcode/formatter/ChatSettings.java
+++ b/chat-formatter/src/com/eternalcode/formatter/ChatSettings.java
@@ -4,6 +4,8 @@ public interface ChatSettings {
 
     boolean isPreFormatting();
 
+    boolean isRelationalPlaceholders();
+
     String getRawFormat(String rank);
 
 }

--- a/chat-formatter/src/com/eternalcode/formatter/config/PluginConfig.java
+++ b/chat-formatter/src/com/eternalcode/formatter/config/PluginConfig.java
@@ -25,8 +25,6 @@ public class PluginConfig implements ChatSettings, PlaceholderStack, TemplateRep
     @Description("# INFO: This option requires to use custom badges like {displayname} and {message} in each message.")
     public boolean preFormatting = false;
 
-    public boolean relationalPlaceholders = false;
-
     public String defaultFormat = "{displayname} {arrow_right} {message}";
 
     @Description({ " ", "# Chat format for ranks (Vault) Support mini-messages and legacy colors" })
@@ -72,6 +70,9 @@ public class PluginConfig implements ChatSettings, PlaceholderStack, TemplateRep
         .put("{arrow_left}", "«")
         .build();
 
+    @Description({ " ", "# Do you want to enable PlaceholderAPI relational placeholders?" })
+    public boolean relationalPlaceholdersEnabled = false;
+
 
     @Override
     public boolean isPreFormatting() {
@@ -79,8 +80,8 @@ public class PluginConfig implements ChatSettings, PlaceholderStack, TemplateRep
     }
 
     @Override
-    public boolean isRelationalPlaceholders() {
-        return relationalPlaceholders;
+    public boolean isRelationalPlaceholdersEnabled() {
+        return relationalPlaceholdersEnabled;
     }
 
     @Override

--- a/chat-formatter/src/com/eternalcode/formatter/config/PluginConfig.java
+++ b/chat-formatter/src/com/eternalcode/formatter/config/PluginConfig.java
@@ -1,13 +1,12 @@
 package com.eternalcode.formatter.config;
 
+import com.eternalcode.formatter.ChatSettings;
+import com.eternalcode.formatter.placeholder.PlaceholderStack;
 import com.eternalcode.formatter.template.Template;
 import com.eternalcode.formatter.template.TemplateRepository;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import net.dzikoysk.cdn.entity.Description;
-import panda.utilities.StringUtils;
-import com.eternalcode.formatter.ChatSettings;
-import com.eternalcode.formatter.placeholder.PlaceholderStack;
 
 import java.util.List;
 import java.util.Map;
@@ -25,6 +24,8 @@ public class PluginConfig implements ChatSettings, PlaceholderStack, TemplateRep
     @Description("# Do you want to use pre chat format? (Other plugins could join custom prefixes etc.)")
     @Description("# INFO: This option requires to use custom badges like {displayname} and {message} in each message.")
     public boolean preFormatting = false;
+
+    public boolean relationalPlaceholders = false;
 
     public String defaultFormat = "{displayname} {arrow_right} {message}";
 
@@ -75,6 +76,11 @@ public class PluginConfig implements ChatSettings, PlaceholderStack, TemplateRep
     @Override
     public boolean isPreFormatting() {
         return preFormatting;
+    }
+
+    @Override
+    public boolean isRelationalPlaceholders() {
+        return relationalPlaceholders;
     }
 
     @Override

--- a/chat-formatter/src/com/eternalcode/formatter/hook/PlaceholderAPIStack.java
+++ b/chat-formatter/src/com/eternalcode/formatter/hook/PlaceholderAPIStack.java
@@ -1,14 +1,19 @@
 package com.eternalcode.formatter.hook;
 
+import com.eternalcode.formatter.placeholder.DoublePlayerPlaceholderStack;
+import com.eternalcode.formatter.placeholder.PlayerPlaceholderStack;
 import me.clip.placeholderapi.PlaceholderAPI;
 import org.bukkit.entity.Player;
-import com.eternalcode.formatter.placeholder.PlayerPlaceholderStack;
 
-public class PlaceholderAPIStack implements PlayerPlaceholderStack {
+public class PlaceholderAPIStack implements PlayerPlaceholderStack, DoublePlayerPlaceholderStack {
 
     @Override
     public String apply(String text, Player target) {
         return PlaceholderAPI.setPlaceholders(target, text);
     }
 
+    @Override
+    public String apply(String text, Player target, Player otherTarget) {
+        return PlaceholderAPI.setRelationalPlaceholders(target, otherTarget, text);
+    }
 }

--- a/chat-formatter/src/com/eternalcode/formatter/placeholder/DoublePlayerPlaceholder.java
+++ b/chat-formatter/src/com/eternalcode/formatter/placeholder/DoublePlayerPlaceholder.java
@@ -1,0 +1,10 @@
+package com.eternalcode.formatter.placeholder;
+
+import org.bukkit.entity.Player;
+
+@FunctionalInterface
+public interface DoublePlayerPlaceholder {
+
+    String extract(Player target, Player otherTarget);
+
+}

--- a/chat-formatter/src/com/eternalcode/formatter/placeholder/DoublePlayerPlaceholderStack.java
+++ b/chat-formatter/src/com/eternalcode/formatter/placeholder/DoublePlayerPlaceholderStack.java
@@ -1,0 +1,9 @@
+package com.eternalcode.formatter.placeholder;
+
+import org.bukkit.entity.Player;
+
+public interface DoublePlayerPlaceholderStack {
+
+    String apply(String text, Player target, Player otherTarget);
+
+}

--- a/chat-formatter/src/com/eternalcode/formatter/placeholder/PlaceholderRegistry.java
+++ b/chat-formatter/src/com/eternalcode/formatter/placeholder/PlaceholderRegistry.java
@@ -11,9 +11,11 @@ public class PlaceholderRegistry {
 
     private final Map<String, Placeholder> placeholders = new HashMap<>();
     private final Map<String, PlayerPlaceholder> playerPlaceholders = new HashMap<>();
+    private final Map<String, DoublePlayerPlaceholder> doublePlayerPlaceholders = new HashMap<>();
 
     private final Set<PlaceholderStack> stacks = new HashSet<>();
     private final Set<PlayerPlaceholderStack> playerStacks = new HashSet<>();
+    private final Set<DoublePlayerPlaceholderStack> doublePlayerStacks = new HashSet<>();
 
     public void placeholder(String key, Placeholder placeholder) {
         this.placeholders.put(key, placeholder);
@@ -23,12 +25,20 @@ public class PlaceholderRegistry {
         this.playerPlaceholders.put(key, placeholder);
     }
 
+    public void doublePlayerPlaceholder(String key, DoublePlayerPlaceholder placeholder) {
+        this.doublePlayerPlaceholders.put(key, placeholder);
+    }
+
     public void stack(PlaceholderStack stack) {
         this.stacks.add(stack);
     }
 
     public void playerStack(PlayerPlaceholderStack stack) {
         this.playerStacks.add(stack);
+    }
+
+    public void doublePlayerStack(DoublePlayerPlaceholderStack stack) {
+        this.doublePlayerStacks.add(stack);
     }
 
     public String format(String text) {
@@ -53,6 +63,18 @@ public class PlaceholderRegistry {
         }
 
         return this.format(text);
+    }
+
+    public String format(String text, Player target, Player otherTarget) {
+        for (DoublePlayerPlaceholderStack stack : doublePlayerStacks) {
+            text = stack.apply(text, target, otherTarget);
+        }
+
+        for (Map.Entry<String, DoublePlayerPlaceholder> entry : doublePlayerPlaceholders.entrySet()) {
+            text = text.replace(entry.getKey(), entry.getValue().extract(target, otherTarget));
+        }
+
+        return this.format(text, target);
     }
 
 }


### PR DESCRIPTION
This PR adds support for [PlaceholderAPI Relational Placeholders](https://github.com/PlaceholderAPI/PlaceholderAPI/wiki/PlaceholderExpansion#relational-placeholders) (such as `%rel_factionsuuid_relation_color%`).

Will likely need some work doing to it in the ChatController for the Paper-Support hook, since it hackishly loops through all recipients and then create a new subset including just that recipient since the TextComponent is now different for every recipient.

Additionally, may be worth adding a check to only make new components for every recipient if the format _actually_ contains a valid relational placeholder:
```
if (this.settings.isRelationalPlaceholdersEnabled() && PlaceholderAPI.getRelationalPlaceholderPattern().matcher(message).find()) {
    // do logic
}
```